### PR TITLE
Fix DNS IaC: 2018-05-01 API + Makefile + hardened script

### DIFF
--- a/dns-config/.github/pull_request_template.md
+++ b/dns-config/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+# Summary
+
+- Purpose of this change and high-level context.
+- Linked issue(s): #
+
+# Changes
+
+- Brief list of resource/record changes.
+
+# Impact
+
+- Zones/records affected and expected external impact (if any).
+
+# What-If Output
+
+Paste the output from `make what-if` here to validate changes.
+
+```
+az deployment group what-if -g rg-dns-zones -f dns-direct2client.bicep -p @dns-direct2client.parameters.json
+Note: The result may contain false positive predictions (noise).
+You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues
+
+Resource and property changes are indicated with this symbol:
+  = Nochange
+
+The deployment will update the following scope:
+
+Scope: /subscriptions/34b8f36d-a89f-4848-8249-c4175ce5533e/resourceGroups/rg-dns-zones
+
+  = Microsoft.Network/dnsZones/direct2client.com.au [2018-05-01]
+  = Microsoft.Network/dnsZones/direct2client.com.au/A/@ [2018-05-01]
+  = Microsoft.Network/dnsZones/direct2client.com.au/CNAME/autodiscover [2018-05-01]
+  = Microsoft.Network/dnsZones/direct2client.com.au/CNAME/selector1._domainkey [2018-05-01]
+  = Microsoft.Network/dnsZones/direct2client.com.au/CNAME/selector2._domainkey [2018-05-01]
+  = Microsoft.Network/dnsZones/direct2client.com.au/CNAME/www [2018-05-01]
+  = Microsoft.Network/dnsZones/direct2client.com.au/MX/@ [2018-05-01]
+  = Microsoft.Network/dnsZones/direct2client.com.au/TXT/@ [2018-05-01]
+  = Microsoft.Network/dnsZones/direct2client.com.au/TXT/_dmarc [2018-05-01]
+
+Resource changes: 9 no change.
+```
+
+# Post-Deploy Verification (optional)
+
+- Run `make ns` and `make verify`. Paste outputs if relevant.

--- a/dns-config/AGENTS.md
+++ b/dns-config/AGENTS.md
@@ -1,0 +1,76 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Root contains infrastructure-as-code for Azure DNS:
+  - `dns-direct2client.bicep`: main template for DNS zones/records.
+  - `dns-direct2client.parameters.json`: parameter values (copy per env).
+  - `install-bicep-az.sh`: helper to install Azure CLI + Bicep.
+  - `CNAME`: DNS alias for GitHub Pages (do not modify unless required).
+
+## Build, Test, and Development Commands
+- Install tooling: `bash ./install-bicep-az.sh` (or ensure `az` and `bicep` are on PATH).
+- Login/subscription: `az login` then `az account set -s <subscription-id>`.
+- Validate compile: `bicep build dns-direct2client.bicep` (checks syntax/lint).
+- What‑if (preview changes):
+  - `az deployment group what-if -g <rg> -f dns-direct2client.bicep -p @dns-direct2client.parameters.json`
+- Deploy:
+  - `az deployment group create -g <rg> -f dns-direct2client.bicep -p @dns-direct2client.parameters.json`
+
+## Coding Style & Naming Conventions
+- Indentation: 2 spaces; UTF-8; LF line endings.
+- Bicep style: `camelCase` for `param`/`var`, `snake_case` not used.
+- Files: `lower-kebab-case.bicep`, `name.environment.parameters.json` (e.g., `dns.prod.parameters.json`).
+- Comments: use `//` for single-line, keep rationales near resources/records.
+
+## Testing Guidelines
+- Prefer `what-if` before every PR and deploy; paste summary in PR.
+- Keep parameter files minimal; one per environment. Validate with `bicep build`.
+- Avoid live changes outside IaC; if needed, capture drift back into Bicep.
+
+## Commit & Pull Request Guidelines
+- Commits: Conventional style (`feat:`, `fix:`, `refactor:`, `chore:`). Scope by area (e.g., `feat(dns): add MX for support`).
+- PRs must include:
+  - Purpose and impact (zones/records affected).
+  - Command output from `what-if` (sanitized) and target resource group.
+  - Linked issue or change ticket. Screenshots optional for portals.
+
+### What-If Example (paste in PR)
+```
+az deployment group what-if -g rg-dns-zones -f dns-direct2client.bicep -p @dns-direct2client.parameters.json
+Note: The result may contain false positive predictions (noise).
+You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues
+
+Resource and property changes are indicated with this symbol:
+  = Nochange
+
+The deployment will update the following scope:
+
+Scope: /subscriptions/34b8f36d-a89f-4848-8249-c4175ce5533e/resourceGroups/rg-dns-zones
+
+  = Microsoft.Network/dnsZones/direct2client.com.au [2018-05-01]
+  = Microsoft.Network/dnsZones/direct2client.com.au/A/@ [2018-05-01]
+  = Microsoft.Network/dnsZones/direct2client.com.au/CNAME/autodiscover [2018-05-01]
+  = Microsoft.Network/dnsZones/direct2client.com.au/CNAME/selector1._domainkey [2018-05-01]
+  = Microsoft.Network/dnsZones/direct2client.com.au/CNAME/selector2._domainkey [2018-05-01]
+  = Microsoft.Network/dnsZones/direct2client.com.au/CNAME/www [2018-05-01]
+  = Microsoft.Network/dnsZones/direct2client.com.au/MX/@ [2018-05-01]
+  = Microsoft.Network/dnsZones/direct2client.com.au/TXT/@ [2018-05-01]
+  = Microsoft.Network/dnsZones/direct2client.com.au/TXT/_dmarc [2018-05-01]
+
+Resource changes: 9 no change.
+```
+
+## Security & Configuration Tips
+- Do not commit secrets or credentials; use Key Vault and `az login` locally.
+- Parameter files may contain hostnames but no secrets; prefer per‑env copies ignored by default if sensitive.
+- Set explicit subscription and resource group to avoid accidental deploys.
+
+## Deploy (Quick Start)
+```
+az login
+az account set -s "MCPP Subscription"
+make what-if
+make deploy
+make ns
+make verify
+```

--- a/dns-config/Makefile
+++ b/dns-config/Makefile
@@ -1,0 +1,23 @@
+RG ?= rg-dns-zones
+ZONE ?= direct2client.com.au
+BICEP ?= dns-direct2client.bicep
+PARAMS ?= dns-direct2client.parameters.json
+
+.PHONY: what-if deploy ns verify
+what-if:
+	az deployment group what-if -g $(RG) -f $(BICEP) -p @$(PARAMS)
+
+deploy:
+	az deployment group create -g $(RG) -f $(BICEP) -p @$(PARAMS)
+
+ns:
+	az network dns zone show -g $(RG) -n $(ZONE) --query nameServers -o tsv
+
+verify:
+	@NS=`az network dns zone show -g $(RG) -n $(ZONE) --query nameServers[0] -o tsv`; \
+	echo "Testing against $$NS"; \
+	command -v dig >/dev/null 2>&1 && { \
+	  dig @$$NS $(ZONE) MX +short || true; \
+	  dig @$$NS www.$(ZONE) CNAME +short || true; \
+	  dig @$$NS $(ZONE) TXT +short || true; \
+	}

--- a/dns-config/dns-direct2client.bicep
+++ b/dns-config/dns-direct2client.bicep
@@ -1,0 +1,129 @@
+// dns-direct2client.bicep
+@description('Resource group must already exist (rg-dns-zones)')
+param zoneName string = 'direct2client.com.au'
+
+@description('Root A record target (web/Front Door/origin)')
+param rootIPv4 string = '13.107.246.31'
+
+@description('CNAME target for www (Front Door endpoint)')
+param wwwTarget string = 'atheryon-e0eteegvahafd3e7.z03.azurefd.net'
+
+@description('M365 MX hostname')
+param mxHost string = 'direct2client-com-au.mail.protection.outlook.com'
+
+@description('SPF string')
+param spf string = 'v=spf1 include:spf.protection.outlook.com -all'
+
+@description('MS verification TXT for M365 domain verification')
+param msVerify string = 'MS=ms51081858'
+
+@description('DMARC policy')
+param dmarc string = 'v=DMARC1; p=reject; rua=mailto:postmaster@direct2client.com.au'
+
+@description('DKIM selector 1 CNAME target')
+param dkimSel1Target string = 'selector1-direct2client-com-au._domainkey.y.netorgft1876138.q-v1.dkim.mail.microsoft.com'
+
+@description('DKIM selector 2 CNAME target')
+param dkimSel2Target string = 'selector2-direct2client-com-au._domainkey.y.netorgft1876138.q-v1.dkim.mail.microsoft.com'
+
+@description('Default TTL in seconds')
+param ttl int = 3600
+
+resource zone 'Microsoft.Network/dnsZones@2018-05-01' = {
+  name: zoneName
+  location: 'global'
+}
+
+resource aRoot 'Microsoft.Network/dnsZones/A@2018-05-01' = {
+  name: '@'
+  parent: zone
+  properties: {
+    TTL: ttl
+    ARecords: [
+      { ipv4Address: rootIPv4 }
+    ]
+  }
+}
+
+resource cnameWww 'Microsoft.Network/dnsZones/CNAME@2018-05-01' = {
+  name: 'www'
+  parent: zone
+  properties: {
+    TTL: ttl
+    CNAMERecord: {
+      cname: wwwTarget
+    }
+  }
+}
+
+resource mxRoot 'Microsoft.Network/dnsZones/MX@2018-05-01' = {
+  name: '@'
+  parent: zone
+  properties: {
+    TTL: ttl
+    MXRecords: [
+      {
+        preference: 0
+        exchange: mxHost
+      }
+    ]
+  }
+}
+
+resource txtRoot 'Microsoft.Network/dnsZones/TXT@2018-05-01' = {
+  name: '@'
+  parent: zone
+  properties: {
+    TTL: ttl
+    TXTRecords: [
+      { value: [ spf ] }
+      { value: [ msVerify ] }
+    ]
+  }
+}
+
+resource txtDmarc 'Microsoft.Network/dnsZones/TXT@2018-05-01' = {
+  name: '_dmarc'
+  parent: zone
+  properties: {
+    TTL: ttl
+    TXTRecords: [
+      { value: [ dmarc ] }
+    ]
+  }
+}
+
+resource cnameAutodiscover 'Microsoft.Network/dnsZones/CNAME@2018-05-01' = {
+  name: 'autodiscover'
+  parent: zone
+  properties: {
+    TTL: ttl
+    CNAMERecord: {
+      cname: 'autodiscover.outlook.com'
+    }
+  }
+}
+
+resource cnameDkimSel1 'Microsoft.Network/dnsZones/CNAME@2018-05-01' = {
+  name: 'selector1._domainkey'
+  parent: zone
+  properties: {
+    TTL: ttl
+    CNAMERecord: {
+      cname: dkimSel1Target
+    }
+  }
+}
+
+resource cnameDkimSel2 'Microsoft.Network/dnsZones/CNAME@2018-05-01' = {
+  name: 'selector2._domainkey'
+  parent: zone
+  properties: {
+    TTL: ttl
+    CNAMERecord: {
+      cname: dkimSel2Target
+    }
+  }
+}
+
+output nameServers array = zone.properties.nameServers

--- a/dns-config/dns-direct2client.parameters.json
+++ b/dns-config/dns-direct2client.parameters.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "zoneName": { "value": "direct2client.com.au" },
+    "rootIPv4": { "value": "13.107.246.31" },
+    "wwwTarget": { "value": "atheryon-e0eteegvahafd3e7.z03.azurefd.net" },
+    "mxHost": { "value": "direct2client-com-au.mail.protection.outlook.com" },
+    "spf": { "value": "v=spf1 include:spf.protection.outlook.com -all" },
+    "msVerify": { "value": "MS=ms51081858" },
+    "dmarc": { "value": "v=DMARC1; p=reject; rua=mailto:postmaster@direct2client.com.au" },
+    "dkimSel1Target": { "value": "selector1-direct2client-com-au._domainkey.y.netorgft1876138.q-v1.dkim.mail.microsoft.com" },
+    "dkimSel2Target": { "value": "selector2-direct2client-com-au._domainkey.y.netorgft1876138.q-v1.dkim.mail.microsoft.com" },
+    "ttl": { "value": 3600 }
+  }
+}

--- a/dns-config/install-bicep-az.sh
+++ b/dns-config/install-bicep-az.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SUBSCRIPTION="MCPP Subscription"
+RG="rg-dns-zones"
+LOCATION="australiaeast"
+ZONE="direct2client.com.au"
+BICEP="dns-direct2client.bicep"
+PARAMS="dns-direct2client.parameters.json"
+
+# sanity checks
+[[ -n "$SUBSCRIPTION" && -n "$RG" && -n "$ZONE" && -f "$BICEP" && -f "$PARAMS" ]] || {
+  echo "One or more required vars/files are missing. Check SUBSCRIPTION/RG/ZONE and $BICEP/$PARAMS"; exit 1; }
+
+# ensure user is logged in
+if ! az account show >/dev/null 2>&1; then
+  echo "Please run az login"
+  exit 1
+fi
+
+# select subscription
+az account set --subscription "$SUBSCRIPTION"
+
+# ensure RG exists (idempotent)
+az group create -n "$RG" -l "$LOCATION" >/dev/null
+
+# deploy bicep
+az deployment group create \
+  --resource-group "$RG" \
+  --template-file "$BICEP" \
+  --parameters @"$PARAMS"
+
+# print Azure name servers
+az network dns zone show -g "$RG" -n "$ZONE" --query nameServers -o tsv
+
+# sanity tests (optional; do not fail if dig missing)
+NS=$(az network dns zone show -g "$RG" -n "$ZONE" --query nameServers[0] -o tsv || true)
+command -v dig >/dev/null 2>&1 && {
+  dig @"$NS" "$ZONE" MX +short || true
+  dig @"$NS" www."$ZONE" CNAME +short || true
+  dig @"$NS" "$ZONE" TXT +short || true
+}

--- a/dns-config/install-bicep-az.sh.save
+++ b/dns-config/install-bicep-az.sh.save
@@ -1,0 +1,22 @@
+# login is assumed done; pick subscription
+az account set --subscription "$SUBSCRIPTION"
+
+# ensure RG exists (idempotent)
+az group create --name "$RG" --location "$LOCATION" >/dev/null
+
+# deploy bicep
+az deployment group create \
+  --resource-group "$RG" \
+  --template-file "$BICEP" \
+  --parameters @"$PARAMS"
+
+# show nameservers we’ll switch to at INSTRA
+echo ">>> Azure NS:"
+az network dns zone show -g "$RG" -n "$ZONE" --query nameServers -o tsv
+
+# quick sanity checks directly against Azure NS (optional)
+NS=$(az network dns zone show -g "$RG" -n "$ZONE" --query nameServers[0] -o tsv)
+echo ">>> Testing against $NS"
+dig @"$NS" "$ZONE" MX +short
+dig @"$NS" www."$ZONE" CNAME +short
+dig @"$NS" "$ZONE" TXT +short


### PR DESCRIPTION
# Summary
Fix Azure DNS IaC to use supported API version 2018-05-01, correct child record syntax with `parent: zone`, add a Makefile for what-if/deploy/verify, and harden the deployment script.

# Changes
- Bicep: pin Microsoft.Network/dnsZones and record types (A, CNAME, MX, TXT) to 2018-05-01; use record-set names ('@', 'www', '_dmarc'); add `parent: zone` for all children; keep params and defaults.
- Script: strict bash flags; az login preflight; explicit subscription select; idempotent RG create; optional `dig` checks; print Azure NS.
- Makefile: targets `what-if`, `deploy`, `ns`, `verify`.
- Docs: updated AGENTS.md with quick deploy and What‑If example; added PR template.

# Impact
- Resource Group: `rg-dns-zones`
- Zone: `direct2client.com.au`
- Expected: No changes after deploy; authoritative DNS managed via IaC with specified records.

# What-If Output
```
az deployment group what-if -g rg-dns-zones -f dns-direct2client.bicep -p @dns-direct2client.parameters.json
Note: The result may contain false positive predictions (noise).
You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues

Resource and property changes are indicated with this symbol:
  = Nochange

The deployment will update the following scope:

Scope: /subscriptions/34b8f36d-a89f-4848-8249-c4175ce5533e/resourceGroups/rg-dns-zones

  = Microsoft.Network/dnsZones/direct2client.com.au [2018-05-01]
  = Microsoft.Network/dnsZones/direct2client.com.au/A/@ [2018-05-01]
  = Microsoft.Network/dnsZones/direct2client.com.au/CNAME/autodiscover [2018-05-01]
  = Microsoft.Network/dnsZones/direct2client.com.au/CNAME/selector1._domainkey [2018-05-01]
  = Microsoft.Network/dnsZones/direct2client.com.au/CNAME/selector2._domainkey [2018-05-01]
  = Microsoft.Network/dnsZones/direct2client.com.au/CNAME/www [2018-05-01]
  = Microsoft.Network/dnsZones/direct2client.com.au/MX/@ [2018-05-01]
  = Microsoft.Network/dnsZones/direct2client.com.au/TXT/@ [2018-05-01]
  = Microsoft.Network/dnsZones/direct2client.com.au/TXT/_dmarc [2018-05-01]

Resource changes: 9 no change.
```

# Post-Deploy Verification
- `make ns` should print four Azure DNS nameservers.
- `make verify` should show MX, www CNAME, and TXT values.
